### PR TITLE
Allow the unsetting of default request options

### DIFF
--- a/requested.js
+++ b/requested.js
@@ -56,8 +56,11 @@ Requested.prototype.merge = function merge(target) {
 
     for (key in arg) {
       if (!Object.prototype.hasOwnProperty.call(arg, key)) continue;
-
-      if ('object' === this.typeof(arg[key])) {
+     
+      // unset items
+      if (this.typeof(arg[key]) === 'undefined') {
+        delete target[key];
+      } else if ('object' === this.typeof(arg[key])) {
         target[key] = this.merge('object' === this.typeof(target[key]) ? target[key] : {}, arg[key]);
       } else {
         target[key] = arg[key];

--- a/test/requested.js
+++ b/test/requested.js
@@ -52,5 +52,16 @@ describe('Requested', function () {
       assume(x.deep.nested).equals('object');
       assume(x.deep.another).equals('key');
     });
+    
+    it('can unset a key', function () {
+      var x = { foo: 'foo' }
+        , y = { foo: undefined }
+        , z = { baz: 'fun' }
+        , x = r.merge(x, y, z);
+
+      assume(x.foo).is.undefined();
+      assume(x.baz).equals('fun');
+
+    });
   });
 });


### PR DESCRIPTION
Sometimes we want to remove certain keys from a merged object, this will allow that.
